### PR TITLE
Move store_build_artifacts from azure to workflow_settings

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-azure:
-  store_build_artifacts: true
 build_platform:
   osx_arm64: osx_64
 conda_build:
@@ -9,3 +7,5 @@ github:
   branch_name: main
   tooling_branch_name: main
 test: native_and_emulated
+workflow_settings:
+  store_build_artifacts: true


### PR DESCRIPTION
## Summary

The conda-forge linter is currently failing on open PRs (e.g. #54) with:

> ❌ In conda-forge.yml: `$.azure = {'store_build_artifacts': True}` is not valid under any of the given schemas

`azure.store_build_artifacts` was deprecated in conda-smithy v3.61.0 (PR conda-forge/conda-smithy#2500) and moved to the new top-level `workflow_settings` key. The `AzureConfig` schema now uses `extra="forbid"`, so the old location is a hard lint error.

This PR moves the key to its new location.

No re-render is included; the next bot re-render will regenerate the CI scripts accordingly.

## Test plan

- [ ] conda-forge-linter passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)